### PR TITLE
Bump poi from 3.9 to 4.1.1 in /java-excel-poi

### DIFF
--- a/java-excel-poi/pom.xml
+++ b/java-excel-poi/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
 		<groupId>org.apache.poi</groupId>
 		<artifactId>poi</artifactId>
-		<version>3.9</version>
+		<version>4.1.1</version>
 	</dependency>
 	<dependency>
 		<groupId>org.apache.poi</groupId>


### PR DESCRIPTION
Bumps poi from 3.9 to 4.1.1.

---
updated-dependencies:
- dependency-name: org.apache.poi:poi dependency-type: direct:production ...